### PR TITLE
Resolved permission issues, updated dependencies.

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,6 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="jbr-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "com.yatik.statussaver"
         minSdk 23
         targetSdk 33
-        versionCode 7
-        versionName "1.7"
+        versionCode 8
+        versionName "1.7.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -25,6 +25,11 @@ android {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+        debug {
+            applicationIdSuffix ".debug"
+            minifyEnabled false
+            shrinkResources false
         }
     }
 
@@ -51,16 +56,13 @@ android {
 dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation "androidx.fragment:fragment:1.5.7"
-    implementation "androidx.fragment:fragment-ktx:1.5.7"
+    implementation "androidx.fragment:fragment-ktx:1.6.1"
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'com.google.android.material:material:1.8.0'
-    implementation "androidx.navigation:navigation-fragment:2.5.3"
-    implementation "androidx.navigation:navigation-fragment-ktx:2.5.3"
-    implementation "androidx.navigation:navigation-ui:2.5.3"
-    implementation "androidx.navigation:navigation-ui-ktx:2.5.3"
-    implementation("androidx.navigation:navigation-dynamic-features-fragment:2.5.3")
-    implementation 'com.github.bumptech.glide:glide:4.12.0'
+    implementation 'com.google.android.material:material:1.9.0'
+    implementation "androidx.navigation:navigation-fragment-ktx:2.6.0"
+    implementation "androidx.navigation:navigation-ui-ktx:2.6.0"
+    implementation("androidx.navigation:navigation-dynamic-features-fragment:2.6.0")
+    implementation 'com.github.bumptech.glide:glide:4.15.1'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/src/main/java/com/yatik/statussaver/ui/SplashActivity.java
+++ b/app/src/main/java/com/yatik/statussaver/ui/SplashActivity.java
@@ -139,49 +139,27 @@ public class SplashActivity extends AppCompatActivity {
 
     private void requestPermission() {
 
-        isReadPermissionGranted = ContextCompat.checkSelfPermission(
-                this, Manifest.permission.READ_EXTERNAL_STORAGE
-        ) == PackageManager.PERMISSION_GRANTED;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
 
-        isWritePermissionGranted = ContextCompat.checkSelfPermission(
-                this, Manifest.permission.WRITE_EXTERNAL_STORAGE
-        ) == PackageManager.PERMISSION_GRANTED;
+            isReadPermissionGranted = ContextCompat.checkSelfPermission(
+                    this, Manifest.permission.READ_EXTERNAL_STORAGE
+            ) == PackageManager.PERMISSION_GRANTED;
 
-        List<String> permissionRequest = new ArrayList<>();
+            isWritePermissionGranted = ContextCompat.checkSelfPermission(
+                    this, Manifest.permission.WRITE_EXTERNAL_STORAGE
+            ) == PackageManager.PERMISSION_GRANTED;
 
-        if (!isReadPermissionGranted) {
-            permissionRequest.add(Manifest.permission.READ_EXTERNAL_STORAGE);
-        }
-        if (!isWritePermissionGranted) {
-            permissionRequest.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
-        }
+            List<String> permissionRequest = new ArrayList<>();
 
-        if (!permissionRequest.isEmpty()) {
-            mPermissionResultLauncher.launch(permissionRequest.toArray(new String[0]));
+            if (!isReadPermissionGranted) {
+                permissionRequest.add(Manifest.permission.READ_EXTERNAL_STORAGE);
+            }
+            if (!isWritePermissionGranted) {
+                permissionRequest.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+            }
 
-        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-            handler.postDelayed(() -> {
-                startActivity(new Intent(SplashActivity.this, MainActivity.class));
-                finish();
-            }, 1500);
-
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            mSharedPreferences = getSharedPreferences("tree", Context.MODE_PRIVATE);
-            String uriString = mSharedPreferences.getString("treeUriString", "");
-
-            if (uriString.matches("")) {
-                //ask for folder permission
-
-                AlertDialog.Builder builder = new AlertDialog.Builder(this);
-
-                builder.setTitle("Folder Access Required")
-                        .setMessage(R.string.folderAccessMessage)
-                        .setCancelable(false)
-                        .setIcon(R.drawable.permission_message)
-                        .setPositiveButton(Html.fromHtml("<font color='#89B3F7'>GRANT PERMISSION</font>"), (dialog, which) -> aboveQPermission());
-                AlertDialog dialog = builder.create();
-                dialog.show();
+            if (!permissionRequest.isEmpty()) {
+                mPermissionResultLauncher.launch(permissionRequest.toArray(new String[0]));
 
             } else {
                 handler.postDelayed(() -> {
@@ -189,6 +167,30 @@ public class SplashActivity extends AppCompatActivity {
                     finish();
                 }, 1500);
             }
+            return;
+        }
+
+        mSharedPreferences = getSharedPreferences("tree", Context.MODE_PRIVATE);
+        String uriString = mSharedPreferences.getString("treeUriString", "");
+
+        if (uriString.matches("")) {
+            //ask for folder permission
+
+            AlertDialog.Builder builder = new AlertDialog.Builder(this);
+
+            builder.setTitle("Folder Access Required")
+                    .setMessage(R.string.folderAccessMessage)
+                    .setCancelable(false)
+                    .setIcon(R.drawable.permission_message)
+                    .setPositiveButton(Html.fromHtml("<font color='#89B3F7'>GRANT PERMISSION</font>"), (dialog, which) -> aboveQPermission());
+            AlertDialog dialog = builder.create();
+            dialog.show();
+
+        } else {
+            handler.postDelayed(() -> {
+                startActivity(new Intent(SplashActivity.this, MainActivity.class));
+                finish();
+            }, 1500);
         }
     }
 


### PR DESCRIPTION
If your target SDK version is 33, then you should use READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE for API level below 29.